### PR TITLE
Fix import (Python3 compliance)

### DIFF
--- a/vallox_websocket_api/__init__.py
+++ b/vallox_websocket_api/__init__.py
@@ -1,3 +1,3 @@
-from client import Client
+from vallox_websocket_api.client import Client
 
 __all__ = ["Client"]

--- a/vallox_websocket_api/client.py
+++ b/vallox_websocket_api/client.py
@@ -2,7 +2,7 @@ import numpy
 import websocket
 from websocket import ABNF, WebSocketException
 
-from constants import vlxDevConstants, vlxOffsetObject
+from vallox_websocket_api.constants import vlxDevConstants, vlxOffsetObject
 
 
 def calculate_offset(aIndex):


### PR DESCRIPTION
vallox_websocket_api (why not just vallox_api???) worked great in Python2,
however in Python 3 the imports failed. We could have worked with relative
imports (import .Client), but I am not sure this works with Python2.

Fix up imports, so that they work with both Python 2 and Python 3. (tested
both)