### PR TITLE
Example of an High level API for the Vallox API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Code will use websockets API that Valox own web interface uses.
 
 ## Supported units
 
-Tested only with **Vallox 145 MV**
+Tested only with **Vallox 145 MV** and **Vallox 270 MV**.
 
 But API should also work with next units:
 
@@ -971,6 +971,24 @@ Basically all that you can get via Modbus connection
  'WS_WEB_UI_DATA_RW_ERROR': 0,
  'WS_WEB_UI_DATA_SEND_REPLY': 0,
  'WS_WEB_UI_DATA_TABLE_BOUNDARY_ERROR': 0}
+ ```
+
+High level API:
+---------------
+
+ ```
+from vallox_websocket_api.vallox import Vallox, PROFILE;
+client = Vallox('192.168.1.1');
+
+client.get_profile(); # RETURNS a PROFILE.* value
+client.set_profile(PROFILE.HOME); # Permanently HOME profile
+client.set_profile(PROFILE.AWAY); # Permanently AWAY profile
+client.set_profile(PROFILE.FIREPLACE); # FIREPLACE mode for configured timeout
+client.set_profile(PROFILE.FIREPLACE, 120); # FIREPLACE mode for 120 min
+client.set_profile(PROFILE.FIREPLACE, 65535); # FIREPLACE mode, never TIMEOUT
+client.set_profile(PROFILE.EXTRA); # EXTRA mode for configured timeout
+client.set_profile(PROFILE.EXTRA, 120); # EXTRA mode for 120 min
+client.set_profile(PROFILE.EXTRA, 65535); # EXTRA mode, never TIMEOUT
  ```
 
 # Reading

--- a/vallox_websocket_api/vallox.py
+++ b/vallox_websocket_api/vallox.py
@@ -1,0 +1,73 @@
+from .constants import vlxDevConstants
+from .client import Client
+
+from enum import Enum #part of the enum34 package under python2
+import logging
+
+class PROFILE(Enum):
+    NONE = 0
+    HOME = 1
+    AWAY = 2
+    BOOST = 3
+    FIREPLACE = 4
+    EXTRA = 5
+#TODO Poor mans Enum in case we don't want no dependency on python2: 
+#def enum(*sequential, **named):
+#    enums = dict(zip(sequential, range(len(sequential))), **named)
+#    reverse = dict((value, key) for key, value in enums.iteritems())
+#    enums['reverse_mapping'] = reverse
+#    return type('Enum', (), enums)
+
+class Vallox(Client):
+    def get_profile(self):
+        """Returns the profile of the fan
+
+        :returns: One of PROFILE.* values or PROFILE.NONE if unknown
+        """
+        s = self.fetch_metrics(['A_CYC_STATE','A_CYC_BOOST_TIMER',
+                                'A_CYC_FIREPLACE_TIMER','A_CYC_EXTRA_TIMER'])
+        
+        if s['A_CYC_EXTRA_TIMER'] > 0: return PROFILE.EXTRA
+        if s['A_CYC_FIREPLACE_TIMER'] > 0: return PROFILE.FIREPLACE
+        if s['A_CYC_BOOST_TIMER'] > 0: return PROFILE.BOOST
+        if s['A_CYC_STATE'] == 1: return PROFILE.AWAY
+        elif s['A_CYC_STATE'] == 0: return PROFILE.HOME
+        return PROFILE.NONE
+
+    
+    def set_profile(self, profile, duration=None):
+        """Set the profile of the fan
+
+        :params:
+          :profile: One of PROFILE.* values
+          :duration: timeout in minutes for the FIREPLACE and EXTRA profiles
+        """
+
+        #duration: None means default configured setting. 65535 means no time out
+        if profile == PROFILE.HOME:
+            self.set_values({'A_CYC_STATE': '0','A_CYC_BOOST_TIMER': '0',
+                             'A_CYC_FIREPLACE_TIMER': '0',
+                             'A_CYC_EXTRA_TIMER': '0'})
+        elif profile == PROFILE.AWAY:
+            self.set_values({'A_CYC_STATE': '1','A_CYC_BOOST_TIMER': '0',
+                             'A_CYC_FIREPLACE_TIMER': '0',
+                             'A_CYC_EXTRA_TIMER': '0'})
+        elif profile == PROFILE.FIREPLACE:
+            if duration is not None:
+                dur = str(duration)
+            else:
+                s = self.fetch_metrics(['A_CYC_FIREPLACE_TIME'])
+                dur = str(s['A_CYC_FIREPLACE_TIME'])
+            logging.warn("Setting FIREPLACE duration to: %s" % dur)
+            self.set_values({'A_CYC_FIREPLACE_TIMER': dur,
+                             'A_CYC_EXTRA_TIMER': '0'})
+        elif profile == PROFILE.EXTRA:
+            if duration is not None:
+                dur = str(duration)
+            else:
+                s = self.fetch_metrics(['A_CYC_EXTRA_TIME'])
+                dur = str(s['A_CYC_EXTRA_TIME'])
+            logging.warn("Setting EXTRA duration to: %s" % dur)
+            self.set_values({'A_CYC_FIREPLACE_TIMER': '0',
+                             'A_CYC_EXTRA_TIMER': dur})
+


### PR DESCRIPTION
Example usage:
 ```
from vallox_websocket_api.vallox import Vallox, PROFILE;
client = Vallox('192.168.1.1');

client.get_profile(); # RETURNS a PROFILE.* value
client.set_profile(PROFILE.HOME); # Permanently HOME profile
client.set_profile(PROFILE.AWAY); # Permanently AWAY profile
client.set_profile(PROFILE.FIREPLACE); # FIREPLACE mode for configured timeout
client.set_profile(PROFILE.FIREPLACE, 120); # FIREPLACE mode for 120 min
client.set_profile(PROFILE.FIREPLACE, 65535); # FIREPLACE mode, never TIMEOUT
client.set_profile(PROFILE.EXTRA); # EXTRA mode for configured timeout
client.set_profile(PROFILE.EXTRA, 120); # EXTRA mode for 120 min
client.set_profile(PROFILE.EXTRA, 65535); # EXTRA mode, never TIMEOUT
 ```

The code relies on enum34 on python, the enum package is included since
python3.4 by default.