### PR TITLE
Fixed celsius temperature conversion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def parse_requirements(filename, parent=None):
 setup(
   name='vallox_websocket_api',
   packages=['vallox_websocket_api'],
-  version='1.2.0',
+  version='1.2.1',
   description='Vallox WebSocket API',
   author='Jevgeni Kiski',
   author_email='yozik04@gmail.com',

--- a/vallox_websocket_api/client.py
+++ b/vallox_websocket_api/client.py
@@ -52,7 +52,7 @@ def calculate_offset(aIndex):
 
 
 def to_celcius(value):
-  return round(value / 100 - 273.15, 1)
+  return round(value / 100.0 - 273.15, 1)
 
 
 class Client:


### PR DESCRIPTION
Due to integer div by integer, conversion cut decimals, making converted Celsius values non-valid.

See e.g. 29642 cK --> Celsius conversions before and after the fix:

In [39]: round(29642/100 - 273.15, 1)
Out[39]: 22.9

In [40]: round(29642/100.0 - 273.15, 1)
Out[40]: 23.3
