### PR TITLE
Fix requirements install during sdist pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.txt
+include requirements.txt


### PR DESCRIPTION
## Background
The requirements.txt file wasn't included in the sdist that is published to PyPI. This meant that `install_requires` in `setup.py` wasn't populated and requirements didn't install.

## Solution
This PR fixes this problem by adding a [`MANIFEST.in` file](https://packaging.python.org/guides/distributing-packages-using-setuptools/#manifest-in) that includes the `requirements.txt` file in the published sdist. We also include the `LICENSE.txt` file, as that is [normal procedure](https://packaging.python.org/guides/distributing-packages-using-setuptools/#license-txt).

## Changes
- Add MANIFEST.in file and include license and requirements files.

## PR validation
### Log from installing the sdist tar.gz on master
```
(test-vallox) martin@martin:~/dev/vallox_websocket_api$ pip install ./dist/vallox_websocket_api-1.5.1.tar.gz 
Processing ./dist/vallox_websocket_api-1.5.1.tar.gz
Building wheels for collected packages: vallox-websocket-api
  Building wheel for vallox-websocket-api (setup.py) ... done
  Stored in directory: /home/martin/.cache/pip/wheels/a8/e5/d2/92ab5bee9da957b7ca3ff790760960e05c4da4f028070a89bd
Successfully built vallox-websocket-api
Installing collected packages: vallox-websocket-api
Successfully installed vallox-websocket-api-1.5.1
```

### Log from installing the sdist tar.gz on this PR branch:
```
(test-vallox) martin@martin:~/dev/vallox_websocket_api$ pip install ./dist/vallox_websocket_api-1.5.1.tar.gz 
Processing ./dist/vallox_websocket_api-1.5.1.tar.gz
Collecting numpy<2.0.0,>=1.0.0 (from vallox-websocket-api==1.5.1)
  Using cached https://files.pythonhosted.org/packages/87/2d/e4656149cbadd3a8a0369fcd1a9c7d61cc7b87b3903b85389c70c989a696/numpy-1.16.4-cp36-cp36m-manylinux1_x86_64.whl
Collecting websocket-client<1.0.0,>=0.32.0 (from vallox-websocket-api==1.5.1)
  Using cached https://files.pythonhosted.org/packages/29/19/44753eab1fdb50770ac69605527e8859468f3c0fd7dc5a76dd9c4dbd7906/websocket_client-0.56.0-py2.py3-none-any.whl
Requirement already satisfied: six in /home/martin/.virtualenvs/test-vallox/lib/python3.6/site-packages (from websocket-client<1.0.0,>=0.32.0->vallox-websocket-api==1.5.1) (1.12.0)
Building wheels for collected packages: vallox-websocket-api
  Building wheel for vallox-websocket-api (setup.py) ... done
  Stored in directory: /home/martin/.cache/pip/wheels/a8/e5/d2/92ab5bee9da957b7ca3ff790760960e05c4da4f028070a89bd
Successfully built vallox-websocket-api
Installing collected packages: numpy, websocket-client, vallox-websocket-api
Successfully installed numpy-1.16.4 vallox-websocket-api-1.5.1 websocket-client-0.56.0
```