### PR TITLE
Split and improve get_info

### DIFF
--- a/vallox_websocket_api/vallox.py
+++ b/vallox_websocket_api/vallox.py
@@ -1,5 +1,6 @@
 import logging
 from enum import IntEnum
+from uuid import UUID
 
 from .client import Client
 
@@ -68,6 +69,7 @@ DEVICE_MODEL = [
 ]
 
 SW_VERSION_METRICS = ["A_CYC_APPL_SW_VERSION_%d" % i for i in range(1, 10)]
+UUID_METRICS = ["A_CYC_UUID{}".format(i) for i in range(0, 8)]
 MODEL_METRIC = "A_CYC_MACHINE_MODEL"
 
 
@@ -82,6 +84,12 @@ def get_model(data):
 
 def get_sw_version(data):
     return ".".join(str(swap16(data[m])) for m in SW_VERSION_METRICS).lstrip(".0")
+
+
+def get_uuid(data):
+    int_values = [data[m] for m in UUID_METRICS]
+    hex_string = "".join([hex(i)[2:] for i in int_values])
+    return UUID(hex_string)
 
 
 def swap16(val):
@@ -190,10 +198,13 @@ class Vallox(Client):
             )
 
     async def get_info(self):
-        data = await self.fetch_metrics(SW_VERSION_METRICS + [MODEL_METRIC])
+        data = await self.fetch_metrics(
+            SW_VERSION_METRICS + [MODEL_METRIC] + UUID_METRICS
+        )
         return {
             "model": get_model(data),
             "sw_version": get_sw_version(data),
+            "uuid": get_uuid(data),
         }
 
     async def get_temperature(self, profile):


### PR DESCRIPTION
I'd like to add registration of the Vallox device to the Homeassistant device registry. As the first step toward that we need to have an unique identifier for the device, and luckily it already provides an UUID for exactly this purpose. This PR makes that available through the API (and hopefully also makes the existing device_info parts more efficient to take advantage of on the HA side).