### PR TITLE
Fix some warnings seen when running tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/tests/test_vallox_info.py
+++ b/tests/test_vallox_info.py
@@ -33,8 +33,8 @@ class TestValloxInfo(asynctest.TestCase):
 
         info = await self.client.get_info()
 
-        self.assertEquals("Vallox 145 MV", info["model"])
-        self.assertEquals("2.0.2", info["sw_version"])
-        self.assertEquals("63580ebc-6358-0000-6358-635863586358", str(info["uuid"]))
+        self.assertEqual("Vallox 145 MV", info["model"])
+        self.assertEqual("2.0.2", info["sw_version"])
+        self.assertEqual("63580ebc-6358-0000-6358-635863586358", str(info["uuid"]))
 
         self.client.fetch_metrics.assert_called()


### PR DESCRIPTION
These changes fix these warnings seen with `pytest tests/`:

```
tests/test_vallox_info.py::TestValloxInfo::testGetInfo
  /Users/slovdahl/dev/vallox_websocket_api/tests/test_vallox_info.py:36: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals("Vallox 145 MV", info["model"])

tests/test_vallox_info.py::TestValloxInfo::testGetInfo
  /Users/slovdahl/dev/vallox_websocket_api/tests/test_vallox_info.py:37: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals("2.0.2", info["sw_version"])

tests/test_vallox_info.py::TestValloxInfo::testGetInfo
  /Users/slovdahl/dev/vallox_websocket_api/tests/test_vallox_info.py:38: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals("63580ebc-6358-0000-6358-635863586358", str(info["uuid"]))
```

And this warning seen with `python3 setup.py test`:

```
/Users/slovdahl/.pyenv/versions/3.10.2/lib/python3.10/site-packages/setuptools/dist.py:717: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
```