### PR TITLE
Bump websockets to 11.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ packages =
     vallox_websocket_api
 python_requires = >=3.6.0, <4
 install_requires =
-    websockets >= 9.1, < 11.0
+    websockets >= 11.0.1, < 12.0
     construct >= 2.9.0, < 3.0.0
 tests_require =
     pytest


### PR DESCRIPTION
Home Assistant wants/needs to update the websockets dependency to 11.0.1, see https://github.com/home-assistant/core/pull/90901.