### PR TITLE
Run CI tests on Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version:
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=46.4.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ["py36", "py37", "py38", "py39", "py310"]
+target-version = ["py39", "py310", "py311", "py312"]
 exclude = 'generated'
 
 [tool.isort]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 license = LGPL 3
 
 [options]


### PR DESCRIPTION
Home Assistant 2024.2 has updated Python to 3.12 too.