### PR TITLE
Add various new settables incl some getters/setters and enums.

### DIFF
--- a/tests/data/test_data_model.py
+++ b/tests/data/test_data_model.py
@@ -5,7 +5,11 @@ import pytest
 from vallox_websocket_api.data.model import DataModel
 
 js_folder = Path(__file__).parent / "js"
-js_files = [js_file.name for js_file in js_folder.glob("*.js")]
+js_files = [
+    js_file.name
+    for js_file in js_folder.glob("*.js")
+    if not js_file.name.startswith("_")
+]
 
 json_folder = Path(__file__).parent.parent.parent / "vallox_websocket_api" / "data"
 json_files = [json_file.name for json_file in json_folder.glob("*.json")]

--- a/tests/test_vallox_sensors.py
+++ b/tests/test_vallox_sensors.py
@@ -254,9 +254,9 @@ async def test_get_sensor_controls_and_modes(vallox, metrics_response):
     )
 
     # Test sensor modes and limits
-    assert data.get_rh_sensor_control_mode() == metrics_response["A_CYC_RH_LEVEL_MODE"]
-    assert data.get_rh_sensor_limit() == metrics_response["A_CYC_RH_BASIC_LEVEL"]
-    assert data.get_co2_sensor_limit() == metrics_response["A_CYC_CO2_THRESHOLD"]
+    assert data.rh_sensor_control_mode == metrics_response["A_CYC_RH_LEVEL_MODE"]
+    assert data.rh_sensor_limit == metrics_response["A_CYC_RH_BASIC_LEVEL"]
+    assert data.co2_sensor_limit == metrics_response["A_CYC_CO2_THRESHOLD"]
 
     # Test supply heating adjust mode
     assert isinstance(data.supply_heating_adjust_mode, SupplyHeatingAdjustMode)

--- a/tests/test_vallox_sensors.py
+++ b/tests/test_vallox_sensors.py
@@ -5,53 +5,64 @@ import pytest
 
 from vallox_websocket_api import (
     Profile,
-    CellState,
     SupplyHeatingAdjustMode,
     DefrostMode,
     ValloxInvalidInputException,
 )
 
 
+@pytest.mark.parametrize(
+    "profile, enabled",
+    [
+        (Profile.HOME, True),
+        (Profile.HOME, False),
+        (Profile.AWAY, True),
+        (Profile.AWAY, False),
+        (Profile.BOOST, True),
+        (Profile.BOOST, False),
+    ],
+)
 @pytest.mark.asyncio
-async def test_set_rh_sensor_control(vallox, ws):
+async def test_set_rh_sensor_control(vallox, profile, enabled):
     """Test setting RH sensor control."""
     vallox.set_values = mock.AsyncMock()
-
-    # Test HOME profile
-    await vallox.set_rh_sensor_control(Profile.HOME, True)
-    vallox.set_values.assert_called_once_with({"A_CYC_HOME_RH_CTRL_ENABLED": True})
-    vallox.set_values.reset_mock()
-
-    # Test AWAY profile
-    await vallox.set_rh_sensor_control(Profile.AWAY, False)
-    vallox.set_values.assert_called_once_with({"A_CYC_AWAY_RH_CTRL_ENABLED": False})
+    await vallox.set_rh_sensor_control(profile, enabled)
+    vallox.set_values.assert_called_once_with({f"A_CYC_{profile.name}_RH_CTRL_ENABLED": enabled})
 
     # Test invalid profile
     with pytest.raises(ValloxInvalidInputException):
         await vallox.set_rh_sensor_control(Profile.FIREPLACE, True)
+    with pytest.raises(ValloxInvalidInputException):
+        await vallox.set_rh_sensor_control(Profile.EXTRA, True)
 
 
+@pytest.mark.parametrize(
+    "profile, enabled",
+    [
+        (Profile.HOME, True),
+        (Profile.HOME, False),
+        (Profile.AWAY, True),
+        (Profile.AWAY, False),
+        (Profile.BOOST, True),
+        (Profile.BOOST, False),
+    ],
+)
 @pytest.mark.asyncio
-async def test_set_co2_sensor_control(vallox, ws):
+async def test_set_co2_sensor_control(vallox, profile, enabled):
     """Test setting CO2 sensor control."""
     vallox.set_values = mock.AsyncMock()
-
-    # Test HOME profile
-    await vallox.set_co2_sensor_control(Profile.HOME, True)
-    vallox.set_values.assert_called_once_with({"A_CYC_HOME_CO2_CTRL_ENABLED": True})
-    vallox.set_values.reset_mock()
-
-    # Test AWAY profile
-    await vallox.set_co2_sensor_control(Profile.AWAY, False)
-    vallox.set_values.assert_called_once_with({"A_CYC_AWAY_CO2_CTRL_ENABLED": False})
+    await vallox.set_co2_sensor_control(profile, enabled)
+    vallox.set_values.assert_called_once_with({f"A_CYC_{profile.name}_CO2_CTRL_ENABLED": enabled})
 
     # Test invalid profile
     with pytest.raises(ValloxInvalidInputException):
         await vallox.set_co2_sensor_control(Profile.FIREPLACE, True)
+    with pytest.raises(ValloxInvalidInputException):
+        await vallox.set_co2_sensor_control(Profile.EXTRA, True)
 
 
 @pytest.mark.asyncio
-async def test_set_sensor_control_mode_and_limits(vallox, ws):
+async def test_set_sensor_control_mode_and_limits(vallox):
     """Test setting sensor control modes and limits."""
     vallox.set_values = mock.AsyncMock()
 
@@ -85,83 +96,143 @@ async def test_set_sensor_control_mode_and_limits(vallox, ws):
         await vallox.set_co2_sensor_limit(2001)  # Above maximum
 
 
+@pytest.mark.parametrize(
+    "adjust_mode",
+    [
+        SupplyHeatingAdjustMode.SUPPLY,
+        SupplyHeatingAdjustMode.EXTRACT,
+        SupplyHeatingAdjustMode.COOLING,
+    ],
+)
 @pytest.mark.asyncio
-async def test_set_supply_heating_adjust_mode(vallox, ws):
+async def test_set_supply_heating_adjust_mode(vallox, adjust_mode):
     """Test setting supply heating adjust mode."""
     vallox.set_values = mock.AsyncMock()
 
-    # Test valid mode
-    await vallox.set_supply_heating_adjust_mode(SupplyHeatingAdjustMode.EXTRACT)
-    vallox.set_values.assert_called_once_with({"A_CYC_SUPPLY_HEATING_ADJUST_MODE": SupplyHeatingAdjustMode.EXTRACT.value})
+    await vallox.set_supply_heating_adjust_mode(adjust_mode)
+    vallox.set_values.assert_called_once_with({"A_CYC_SUPPLY_HEATING_ADJUST_MODE": adjust_mode.value})
 
     # Test invalid mode
     with pytest.raises(ValloxInvalidInputException):
         await vallox.set_supply_heating_adjust_mode(5)
 
 
+@pytest.mark.parametrize(
+    "defrost_mode",
+    [
+        DefrostMode.BYPASS,
+        DefrostMode.FAN_STOP,
+    ],
+)
 @pytest.mark.asyncio
-async def test_set_defrost_mode(vallox, ws):
+async def test_set_defrost_mode(vallox, defrost_mode):
     """Test setting defrost mode."""
     vallox.set_values = mock.AsyncMock()
 
-    # Test valid mode
-    await vallox.set_defrost_mode(DefrostMode.FAN_STOP)
-    vallox.set_values.assert_called_once_with({"A_CYC_DEFROST_MODE": DefrostMode.FAN_STOP.value})
+    await vallox.set_defrost_mode(defrost_mode)
+    vallox.set_values.assert_called_once_with({"A_CYC_DEFROST_MODE": defrost_mode.value})
 
     # Test invalid mode
     with pytest.raises(ValloxInvalidInputException):
         await vallox.set_defrost_mode(5)
 
 
+@pytest.mark.parametrize(
+    "metrics_response",
+    [
+        {
+            "A_CYC_HOME_RH_CTRL_ENABLED": 1,
+            "A_CYC_AWAY_RH_CTRL_ENABLED": 1,
+            "A_CYC_BOOST_RH_CTRL_ENABLED": 1,
+            "A_CYC_HOME_CO2_CTRL_ENABLED": 1,
+            "A_CYC_AWAY_CO2_CTRL_ENABLED": 1,
+            "A_CYC_BOOST_CO2_CTRL_ENABLED": 1,
+            "A_CYC_RH_LEVEL_MODE": 0,
+            "A_CYC_RH_BASIC_LEVEL": 58,
+            "A_CYC_CO2_THRESHOLD": 800,
+            "A_CYC_SUPPLY_HEATING_ADJUST_MODE": 0,
+            "A_CYC_DEFROST_MODE": 0,
+        },
+        {
+            "A_CYC_HOME_RH_CTRL_ENABLED": 0,
+            "A_CYC_AWAY_RH_CTRL_ENABLED": 0,
+            "A_CYC_BOOST_RH_CTRL_ENABLED": 0,
+            "A_CYC_HOME_CO2_CTRL_ENABLED": 0,
+            "A_CYC_AWAY_CO2_CTRL_ENABLED": 0,
+            "A_CYC_BOOST_CO2_CTRL_ENABLED": 0,
+            "A_CYC_RH_LEVEL_MODE": 1,
+            "A_CYC_RH_BASIC_LEVEL": 50,
+            "A_CYC_CO2_THRESHOLD": 750,
+            "A_CYC_SUPPLY_HEATING_ADJUST_MODE": 1,
+            "A_CYC_DEFROST_MODE": 1,
+        },
+        {
+            "A_CYC_HOME_RH_CTRL_ENABLED": 0,
+            "A_CYC_AWAY_RH_CTRL_ENABLED": 1,
+            "A_CYC_BOOST_RH_CTRL_ENABLED": 0,
+            "A_CYC_HOME_CO2_CTRL_ENABLED": 1,
+            "A_CYC_AWAY_CO2_CTRL_ENABLED": 0,
+            "A_CYC_BOOST_CO2_CTRL_ENABLED": 1,
+            "A_CYC_RH_LEVEL_MODE": 0,
+            "A_CYC_RH_BASIC_LEVEL": 60,
+            "A_CYC_CO2_THRESHOLD": 850,
+            "A_CYC_SUPPLY_HEATING_ADJUST_MODE": 2,
+            "A_CYC_DEFROST_MODE": 1,
+        },
+        {
+            "A_CYC_HOME_RH_CTRL_ENABLED": 1,
+            "A_CYC_AWAY_RH_CTRL_ENABLED": 0,
+            "A_CYC_BOOST_RH_CTRL_ENABLED": 1,
+            "A_CYC_HOME_CO2_CTRL_ENABLED": 0,
+            "A_CYC_AWAY_CO2_CTRL_ENABLED": 1,
+            "A_CYC_BOOST_CO2_CTRL_ENABLED": 0,
+            "A_CYC_RH_LEVEL_MODE": 1,
+            "A_CYC_RH_BASIC_LEVEL": 55,
+            "A_CYC_CO2_THRESHOLD": 900,
+            "A_CYC_SUPPLY_HEATING_ADJUST_MODE": 0,
+            "A_CYC_DEFROST_MODE": 0,
+        },
+    ],
+)
 @pytest.mark.asyncio
-async def test_get_sensor_controls_and_modes(vallox):
+async def test_get_sensor_controls_and_modes(vallox, metrics_response):
     """Test getting sensor controls and modes."""
     # Mock the metrics response
-    vallox.fetch_metrics = mock.AsyncMock(return_value={
-        "A_CYC_HOME_RH_CTRL_ENABLED": 1,
-        "A_CYC_AWAY_RH_CTRL_ENABLED": 1,
-        "A_CYC_BOOST_RH_CTRL_ENABLED": 1,
-        "A_CYC_HOME_CO2_CTRL_ENABLED": 1,
-        "A_CYC_AWAY_CO2_CTRL_ENABLED": 1,
-        "A_CYC_BOOST_CO2_CTRL_ENABLED": 1,
-        "A_CYC_RH_LEVEL_MODE": 0,
-        "A_CYC_RH_BASIC_LEVEL": 58,
-        "A_CYC_CO2_THRESHOLD": 800,
-        "A_CYC_SUPPLY_HEATING_ADJUST_MODE": 0,
-        "A_CYC_DEFROST_MODE": 0,
-    })
+    vallox.fetch_metrics = mock.AsyncMock(return_value=metrics_response)
 
     data = await vallox.fetch_metric_data()
 
     # Test RH sensor control status
-    assert data.get_rh_sensor_control(Profile.HOME) == 1
-    assert data.get_rh_sensor_control(Profile.AWAY) == 1
-    assert data.get_rh_sensor_control(Profile.BOOST) == 1
+    assert data.get_rh_sensor_control(Profile.HOME) == metrics_response["A_CYC_HOME_RH_CTRL_ENABLED"]
+    assert data.get_rh_sensor_control(Profile.AWAY) == metrics_response["A_CYC_AWAY_RH_CTRL_ENABLED"]
+    assert data.get_rh_sensor_control(Profile.BOOST) == metrics_response["A_CYC_BOOST_RH_CTRL_ENABLED"]
 
     # Test CO2 sensor control status
-    assert data.get_co2_sensor_control(Profile.HOME) == 1
-    assert data.get_co2_sensor_control(Profile.AWAY) == 1
-    assert data.get_co2_sensor_control(Profile.BOOST) == 1
+    assert data.get_co2_sensor_control(Profile.HOME) == metrics_response["A_CYC_HOME_CO2_CTRL_ENABLED"]
+    assert data.get_co2_sensor_control(Profile.AWAY) == metrics_response["A_CYC_AWAY_CO2_CTRL_ENABLED"]
+    assert data.get_co2_sensor_control(Profile.BOOST) == metrics_response["A_CYC_BOOST_CO2_CTRL_ENABLED"]
 
     # Test sensor modes and limits
-    assert data.get_rh_sensor_control_mode() == 0  # Automatic mode
-    assert data.get_rh_sensor_limit() == 58
-    assert data.get_co2_sensor_limit() == 800
+    assert data.get_rh_sensor_control_mode() == metrics_response["A_CYC_RH_LEVEL_MODE"]
+    assert data.get_rh_sensor_limit() == metrics_response["A_CYC_RH_BASIC_LEVEL"]
+    assert data.get_co2_sensor_limit() == metrics_response["A_CYC_CO2_THRESHOLD"]
 
     # Test supply heating adjust mode
-    assert data.supply_heating_adjust_mode == SupplyHeatingAdjustMode.SUPPLY.value
-    assert data.get_supply_heating_adjust_mode() == SupplyHeatingAdjustMode.SUPPLY
-    assert data.get_supply_heating_adjust_mode_name() == "Supply"
+    assert data.supply_heating_adjust_mode == SupplyHeatingAdjustMode(metrics_response["A_CYC_SUPPLY_HEATING_ADJUST_MODE"])
+    assert data.supply_heating_adjust_mode.name == SupplyHeatingAdjustMode(metrics_response["A_CYC_SUPPLY_HEATING_ADJUST_MODE"]).name
 
     # Test defrost mode
-    assert data.defrost_mode == DefrostMode.BYPASS.value
-    assert data.get_defrost_mode() == DefrostMode.BYPASS
-    assert data.get_defrost_mode_name() == "Bypass"
+    assert data.defrost_mode == DefrostMode(metrics_response["A_CYC_DEFROST_MODE"])
+    assert data.defrost_mode.name == DefrostMode(metrics_response["A_CYC_DEFROST_MODE"]).name
 
-    # Test invalid profiles
+    # Test valid profiles without specific RH and CO2 sensor control metrics
     with pytest.raises(ValloxInvalidInputException):
         data.get_rh_sensor_control(Profile.FIREPLACE)
     with pytest.raises(ValloxInvalidInputException):
+        data.get_rh_sensor_control(Profile.EXTRA)
+    with pytest.raises(ValloxInvalidInputException):
         data.get_co2_sensor_control(Profile.FIREPLACE)
+    with pytest.raises(ValloxInvalidInputException):
+        data.get_co2_sensor_control(Profile.EXTRA)
 
     vallox.fetch_metrics.assert_called_once()

--- a/tests/test_vallox_sensors.py
+++ b/tests/test_vallox_sensors.py
@@ -1,0 +1,167 @@
+"""Tests for Vallox WebSocket API sensor control functionality."""
+from unittest import mock
+
+import pytest
+
+from vallox_websocket_api import (
+    Profile,
+    CellState,
+    SupplyHeatingAdjustMode,
+    DefrostMode,
+    ValloxInvalidInputException,
+)
+
+
+@pytest.mark.asyncio
+async def test_set_rh_sensor_control(vallox, ws):
+    """Test setting RH sensor control."""
+    vallox.set_values = mock.AsyncMock()
+
+    # Test HOME profile
+    await vallox.set_rh_sensor_control(Profile.HOME, True)
+    vallox.set_values.assert_called_once_with({"A_CYC_HOME_RH_CTRL_ENABLED": True})
+    vallox.set_values.reset_mock()
+
+    # Test AWAY profile
+    await vallox.set_rh_sensor_control(Profile.AWAY, False)
+    vallox.set_values.assert_called_once_with({"A_CYC_AWAY_RH_CTRL_ENABLED": False})
+
+    # Test invalid profile
+    with pytest.raises(ValloxInvalidInputException):
+        await vallox.set_rh_sensor_control(Profile.FIREPLACE, True)
+
+
+@pytest.mark.asyncio
+async def test_set_co2_sensor_control(vallox, ws):
+    """Test setting CO2 sensor control."""
+    vallox.set_values = mock.AsyncMock()
+
+    # Test HOME profile
+    await vallox.set_co2_sensor_control(Profile.HOME, True)
+    vallox.set_values.assert_called_once_with({"A_CYC_HOME_CO2_CTRL_ENABLED": True})
+    vallox.set_values.reset_mock()
+
+    # Test AWAY profile
+    await vallox.set_co2_sensor_control(Profile.AWAY, False)
+    vallox.set_values.assert_called_once_with({"A_CYC_AWAY_CO2_CTRL_ENABLED": False})
+
+    # Test invalid profile
+    with pytest.raises(ValloxInvalidInputException):
+        await vallox.set_co2_sensor_control(Profile.FIREPLACE, True)
+
+
+@pytest.mark.asyncio
+async def test_set_sensor_control_mode_and_limits(vallox, ws):
+    """Test setting sensor control modes and limits."""
+    vallox.set_values = mock.AsyncMock()
+
+    # Test setting RH sensor mode
+    await vallox.set_rh_sensor_control_mode(1)  # Manual mode
+    vallox.set_values.assert_called_once_with({"A_CYC_RH_LEVEL_MODE": 1})
+    vallox.set_values.reset_mock()
+
+    # Test setting RH sensor limit
+    await vallox.set_rh_sensor_limit(65)
+    vallox.set_values.assert_called_once_with({"A_CYC_RH_BASIC_LEVEL": 65})
+    vallox.set_values.reset_mock()
+
+    # Test setting CO2 sensor limit
+    await vallox.set_co2_sensor_limit(1000)
+    vallox.set_values.assert_called_once_with({"A_CYC_CO2_THRESHOLD": 1000})
+    vallox.set_values.reset_mock()
+
+    # Test invalid RH sensor mode
+    with pytest.raises(ValloxInvalidInputException):
+        await vallox.set_rh_sensor_control_mode(2)
+
+    # Test invalid RH sensor limit
+    with pytest.raises(ValloxInvalidInputException):
+        await vallox.set_rh_sensor_limit(101)
+
+    # Test invalid CO2 sensor limits
+    with pytest.raises(ValloxInvalidInputException):
+        await vallox.set_co2_sensor_limit(499)  # Below minimum
+    with pytest.raises(ValloxInvalidInputException):
+        await vallox.set_co2_sensor_limit(2001)  # Above maximum
+
+
+@pytest.mark.asyncio
+async def test_set_supply_heating_adjust_mode(vallox, ws):
+    """Test setting supply heating adjust mode."""
+    vallox.set_values = mock.AsyncMock()
+
+    # Test valid mode
+    await vallox.set_supply_heating_adjust_mode(SupplyHeatingAdjustMode.EXTRACT)
+    vallox.set_values.assert_called_once_with({"A_CYC_SUPPLY_HEATING_ADJUST_MODE": SupplyHeatingAdjustMode.EXTRACT.value})
+
+    # Test invalid mode
+    with pytest.raises(ValloxInvalidInputException):
+        await vallox.set_supply_heating_adjust_mode(5)
+
+
+@pytest.mark.asyncio
+async def test_set_defrost_mode(vallox, ws):
+    """Test setting defrost mode."""
+    vallox.set_values = mock.AsyncMock()
+
+    # Test valid mode
+    await vallox.set_defrost_mode(DefrostMode.FAN_STOP)
+    vallox.set_values.assert_called_once_with({"A_CYC_DEFROST_MODE": DefrostMode.FAN_STOP.value})
+
+    # Test invalid mode
+    with pytest.raises(ValloxInvalidInputException):
+        await vallox.set_defrost_mode(5)
+
+
+@pytest.mark.asyncio
+async def test_get_sensor_controls_and_modes(vallox):
+    """Test getting sensor controls and modes."""
+    # Mock the metrics response
+    vallox.fetch_metrics = mock.AsyncMock(return_value={
+        "A_CYC_HOME_RH_CTRL_ENABLED": 1,
+        "A_CYC_AWAY_RH_CTRL_ENABLED": 1,
+        "A_CYC_BOOST_RH_CTRL_ENABLED": 1,
+        "A_CYC_HOME_CO2_CTRL_ENABLED": 1,
+        "A_CYC_AWAY_CO2_CTRL_ENABLED": 1,
+        "A_CYC_BOOST_CO2_CTRL_ENABLED": 1,
+        "A_CYC_RH_LEVEL_MODE": 0,
+        "A_CYC_RH_BASIC_LEVEL": 58,
+        "A_CYC_CO2_THRESHOLD": 800,
+        "A_CYC_SUPPLY_HEATING_ADJUST_MODE": 0,
+        "A_CYC_DEFROST_MODE": 0,
+    })
+
+    data = await vallox.fetch_metric_data()
+
+    # Test RH sensor control status
+    assert data.get_rh_sensor_control(Profile.HOME) == 1
+    assert data.get_rh_sensor_control(Profile.AWAY) == 1
+    assert data.get_rh_sensor_control(Profile.BOOST) == 1
+
+    # Test CO2 sensor control status
+    assert data.get_co2_sensor_control(Profile.HOME) == 1
+    assert data.get_co2_sensor_control(Profile.AWAY) == 1
+    assert data.get_co2_sensor_control(Profile.BOOST) == 1
+
+    # Test sensor modes and limits
+    assert data.get_rh_sensor_control_mode() == 0  # Automatic mode
+    assert data.get_rh_sensor_limit() == 58
+    assert data.get_co2_sensor_limit() == 800
+
+    # Test supply heating adjust mode
+    assert data.supply_heating_adjust_mode == SupplyHeatingAdjustMode.SUPPLY.value
+    assert data.get_supply_heating_adjust_mode() == SupplyHeatingAdjustMode.SUPPLY
+    assert data.get_supply_heating_adjust_mode_name() == "Supply"
+
+    # Test defrost mode
+    assert data.defrost_mode == DefrostMode.BYPASS.value
+    assert data.get_defrost_mode() == DefrostMode.BYPASS
+    assert data.get_defrost_mode_name() == "Bypass"
+
+    # Test invalid profiles
+    with pytest.raises(ValloxInvalidInputException):
+        data.get_rh_sensor_control(Profile.FIREPLACE)
+    with pytest.raises(ValloxInvalidInputException):
+        data.get_co2_sensor_control(Profile.FIREPLACE)
+
+    vallox.fetch_metrics.assert_called_once()

--- a/vallox_websocket_api/__init__.py
+++ b/vallox_websocket_api/__init__.py
@@ -7,12 +7,12 @@ from .exceptions import (
 )
 from .vallox import (
     Alarm,
+    CellState,
+    DefrostMode,
     MetricData,
     Profile,
-    Vallox,
-    CellState,
     SupplyHeatingAdjustMode,
-    DefrostMode
+    Vallox,
 )
 
 __all__ = [

--- a/vallox_websocket_api/__init__.py
+++ b/vallox_websocket_api/__init__.py
@@ -5,7 +5,15 @@ from .exceptions import (
     ValloxInvalidInputException,
     ValloxWebsocketException,
 )
-from .vallox import Alarm, MetricData, Profile, Vallox
+from .vallox import (
+    Alarm,
+    MetricData,
+    Profile,
+    Vallox,
+    CellState,
+    SupplyHeatingAdjustMode,
+    DefrostMode
+)
 
 __all__ = [
     "Alarm",
@@ -18,6 +26,9 @@ __all__ = [
     "ValloxInvalidInputException",
     "ValloxApiException",
     "ValloxWebsocketException",
+    "CellState",
+    "SupplyHeatingAdjustMode",
+    "DefrostMode",
 ]
 
-__version__ = "5.3.0"
+__version__ = "5.3.1"

--- a/vallox_websocket_api/client.py
+++ b/vallox_websocket_api/client.py
@@ -106,6 +106,17 @@ class Client:
         re.compile(r"^A_CYC_FAULT_ACTIVITY(?:_\d{1,2})?$"),
         re.compile(r"^A_CYC_BYPASS_LOCKED$"),
         re.compile(r"^A_CYC_.*_SETPOINT$"),
+        re.compile(r"^A_CYC_(?:HOME|AWAY|BOOST)_RH_CTRL_ENABLED$"),
+        re.compile(r"^A_CYC_(?:HOME|AWAY|BOOST)_CO2_CTRL_ENABLED$"),
+        re.compile(r"^A_CYC_CO2_THRESHOLD$"),
+        re.compile(r"^A_CYC_RH_LEVEL_MODE$"),
+        re.compile(r"^A_CYC_RH_BASIC_LEVEL$"),
+        re.compile(r"^A_CYC_PARTIAL_BYPASS$"),
+        re.compile(r"^A_CYC_SUPPLY_HEATING_ADJUST_MODE$"),
+        re.compile(r"^A_CYC_POST_HEATER_WINTER_SETPOINT$"),
+        re.compile(r"^A_CYC_COOLRECOVERY_DISABLED$"),
+        re.compile(r"^A_CYC_DEFROST_MODE$"),
+        re.compile(r"^A_CYC_SUPPLY_AIR_DEFROST_TEMP$"),
     }
 
     _settable_addresses: Dict[int, type]

--- a/vallox_websocket_api/vallox.py
+++ b/vallox_websocket_api/vallox.py
@@ -276,66 +276,26 @@ class MetricData:
         return filter_change_date + timedelta(days=int(interval))
 
     @property
-    def supply_heating_adjust_mode(self) -> Optional[int]:
-        """Get the current supply heating adjust mode.
-        Returns:
-            int: 0 (supply), 1 (extract), or 2 (cooling)
-        """
-        return self.get("A_CYC_SUPPLY_HEATING_ADJUST_MODE")
-
-    def get_supply_heating_adjust_mode(self) -> Optional[SupplyHeatingAdjustMode]:
+    def supply_heating_adjust_mode(self) -> Optional[SupplyHeatingAdjustMode]:
         """Get the current supply heating adjust mode.
         Returns:
             SupplyHeatingAdjustMode: 'Supply'(0), 'Extract' (1), or 'Cooling' (2)
         """
-        mode = self.supply_heating_adjust_mode
+        mode = self.get("A_CYC_SUPPLY_HEATING_ADJUST_MODE")
         if mode is None:
             return None
         return SupplyHeatingAdjustMode(mode)
 
-    def get_supply_heating_adjust_mode_name(self) -> Optional[str]:
-        """Get the current supply heating adjust mode as a string.
-        Returns:
-            str: 'Supply', 'Extract', or 'Cooling'
-        """
-        mode = self.get_supply_heating_adjust_mode()
-        if mode == SupplyHeatingAdjustMode.SUPPLY:
-            return "Supply"
-        if mode == SupplyHeatingAdjustMode.EXTRACT:
-            return "Extract"
-        if mode == SupplyHeatingAdjustMode.COOLING:
-            return "Cooling"
-        return None
-
     @property
-    def defrost_mode(self) -> Optional[int]:
-        """Get the current defrost mode.
-        Returns:
-            int: 0 (bypass), 1 (fanstop)
-        """
-        return self.get("A_CYC_DEFROST_MODE")
-
-    def get_defrost_mode(self) -> Optional[DefrostMode]:
+    def defrost_mode(self) -> Optional[DefrostMode]:
         """Get the current supply heating adjust mode.
         Returns:
             DefrostMode: 'Bypass'(0), 'Fanstop' (1)
         """
-        mode = self.defrost_mode
+        mode = self.get("A_CYC_DEFROST_MODE")
         if mode is None:
             return None
         return DefrostMode(mode)
-
-    def get_defrost_mode_name(self) -> Optional[str]:
-        """Get the current defrost mode as a string.
-        Returns:
-            str: 'Bypass', 'Fanstop'
-        """
-        mode = self.get_defrost_mode()
-        if mode == DefrostMode.BYPASS:
-            return "Bypass"
-        if mode == DefrostMode.FAN_STOP:
-            return "Fanstop"
-        return None
 
     def get_temperature_setting(self, profile: Profile) -> Optional[float]:
         """Get the temperature setting for the profile"""
@@ -604,19 +564,19 @@ class Vallox(Client):
         """Set the RH sensor mode to manual (1) or automatic (0)"""
         if mode < 0 or mode > 1:
             raise ValloxInvalidInputException("RH sensor control mode must be 0 (automatic) or 1 (manual)")
-        return self.set_values({SET_RH_SENSOR_CONTROL_MODE: mode})
+        await self.set_values({SET_RH_SENSOR_CONTROL_MODE: mode})
 
     async def set_rh_sensor_limit(self, percent: int) -> None:
         """Set the RH sensor limit (0-100). Only relevant if the RH sensor mode is set to 'manual'."""
         if percent < 0 or percent > 100:
             raise ValloxInvalidInputException("RH sensor limit must be between 0 and 100")
-        return self.set_values({SET_RH_SENSOR_CONTROL_LIMIT: percent})
+        await self.set_values({SET_RH_SENSOR_CONTROL_LIMIT: percent})
 
     async def set_co2_sensor_limit(self, ppm: int) -> None:
         """Set the CO2 sensor ppm limit (500-2000)."""
         if ppm < 500 or ppm > 2000:
             raise ValloxInvalidInputException("CO2 sensor limit must be between 500 and 2000")
-        return self.set_values({SET_CO2_SENSOR_CONTROL_LIMIT: ppm})
+        await self.set_values({SET_CO2_SENSOR_CONTROL_LIMIT: ppm})
 
     async def set_supply_heating_adjust_mode(self, mode: SupplyHeatingAdjustMode) -> None:
         """Set the supply heating adjust mode.

--- a/vallox_websocket_api/vallox.py
+++ b/vallox_websocket_api/vallox.py
@@ -614,7 +614,7 @@ class Vallox(Client):
 
     async def set_co2_sensor_limit(self, ppm: int) -> None:
         """Set the CO2 sensor ppm limit (500-2000)."""
-        if percent < 500 or percent > 2000:
+        if ppm < 500 or ppm > 2000:
             raise ValloxInvalidInputException("CO2 sensor limit must be between 500 and 2000")
         return self.set_values({SET_CO2_SENSOR_CONTROL_LIMIT: ppm})
 

--- a/vallox_websocket_api/vallox.py
+++ b/vallox_websocket_api/vallox.py
@@ -348,15 +348,18 @@ class MetricData:
             return self.get("A_CYC_EXTRA_TIMER")
         return None
 
-    def get_rh_sensor_control_mode(self) -> Optional[int]:
+    @property
+    def rh_sensor_control_mode(self) -> Optional[int]:
         """Return the RH sensor control mode (0 for automatic, 1 for manual)"""
         return self.get(SET_RH_SENSOR_CONTROL_MODE)
 
-    def get_rh_sensor_limit(self) -> Optional[int]:
+    @property
+    def rh_sensor_limit(self) -> Optional[int]:
         """Return the RH sensor limit percentage (0-100). Only relevant if the RH sensor mode is set to 'manual'."""
         return self.get(SET_RH_SENSOR_CONTROL_LIMIT)
 
-    def get_co2_sensor_limit(self) -> Optional[int]:
+    @property
+    def co2_sensor_limit(self) -> Optional[int]:
         """Return the CO2 sensor ppm limit (500-2000)."""
         return self.get(SET_CO2_SENSOR_CONTROL_LIMIT)
 

--- a/vallox_websocket_api/vallox.py
+++ b/vallox_websocket_api/vallox.py
@@ -349,9 +349,10 @@ class MetricData:
         return None
 
     @property
-    def rh_sensor_control_mode(self) -> Optional[int]:
+    def rh_sensor_manual_control_mode(self) -> Optional[bool]:
         """Return the RH sensor control mode (0 for automatic, 1 for manual)"""
-        return self.get(SET_RH_SENSOR_CONTROL_MODE)
+        mode = self.get(SET_RH_SENSOR_CONTROL_MODE)
+        return bool(mode) if mode is not None else None
 
     @property
     def rh_sensor_limit(self) -> Optional[int]:
@@ -572,9 +573,9 @@ class Vallox(Client):
 
         await self.set_values({setting: enable})
 
-    async def set_rh_sensor_control_mode(self, mode: int) -> None:
-        """Set the RH sensor mode to manual (1) or automatic (0)"""
-        if mode < 0 or mode > 1:
+    async def set_rh_sensor_manual_control_mode(self, mode: int) -> None:
+        """Set the RH sensor control mode (0 for automatic, 1 for manual)"""
+        if mode not in (0, 1):
             raise ValloxInvalidInputException(
                 "RH sensor control mode must be 0 (automatic) or 1 (manual)"
             )

--- a/vallox_websocket_api/vallox.py
+++ b/vallox_websocket_api/vallox.py
@@ -47,24 +47,28 @@ PROFILE_TO_SET_CO2_SENSOR_CONTROL_METRIC_MAP = {
     Profile.BOOST: "A_CYC_BOOST_CO2_CTRL_ENABLED",
 }
 
-SET_RH_SENSOR_CONTROL_MODE   = "A_CYC_RH_LEVEL_MODE"
-SET_RH_SENSOR_CONTROL_LIMIT  = "A_CYC_RH_BASIC_LEVEL"
+SET_RH_SENSOR_CONTROL_MODE = "A_CYC_RH_LEVEL_MODE"
+SET_RH_SENSOR_CONTROL_LIMIT = "A_CYC_RH_BASIC_LEVEL"
 SET_CO2_SENSOR_CONTROL_LIMIT = "A_CYC_CO2_THRESHOLD"
 
+
 class CellState(IntEnum):
-    HEAT_RECOVERY = 0 # C_CYC_CELL_STATE_HEATRECO
-    COOL_RECOVERY = 1 # C_CYC_CELL_STATE_COOLRECO
-    BYPASS        = 2 # C_CYC_CELL_STATE_BYPASS
-    DEFROST       = 3 # C_CYC_CELL_STATE_DEFROST
+    HEAT_RECOVERY = 0  # C_CYC_CELL_STATE_HEATRECO
+    COOL_RECOVERY = 1  # C_CYC_CELL_STATE_COOLRECO
+    BYPASS = 2  # C_CYC_CELL_STATE_BYPASS
+    DEFROST = 3  # C_CYC_CELL_STATE_DEFROST
+
 
 class SupplyHeatingAdjustMode(IntEnum):
-    SUPPLY  = 0 # C_CYC_HEATING_SUPPLY
-    EXTRACT = 1 # C_CYC_HEATING_EXTRACT
-    COOLING = 2 # C_CYC_HEATING_COOLING
+    SUPPLY = 0  # C_CYC_HEATING_SUPPLY
+    EXTRACT = 1  # C_CYC_HEATING_EXTRACT
+    COOLING = 2  # C_CYC_HEATING_COOLING
+
 
 class DefrostMode(IntEnum):
-    BYPASS   = 0 # C_CYC_BYPASS_MODE
-    FAN_STOP = 1 # C_CYC_FAN_STOP_MODE
+    BYPASS = 0  # C_CYC_BYPASS_MODE
+    FAN_STOP = 1  # C_CYC_FAN_STOP_MODE
+
 
 DEVICE_MODEL = [
     None,
@@ -222,7 +226,7 @@ class MetricData:
         return UUID(hex_string)
 
     @property
-    def info(self) -> Dict[str, Union[str, UUID]]:
+    def info(self) -> Dict[str, Union[str, UUID, None]]:
         """Get the unit info as a dictionary"""
         return {
             "model": self.model,
@@ -282,9 +286,10 @@ class MetricData:
             SupplyHeatingAdjustMode: 'Supply'(0), 'Extract' (1), or 'Cooling' (2)
         """
         mode = self.get("A_CYC_SUPPLY_HEATING_ADJUST_MODE")
-        if mode is None:
+        try:
+            return SupplyHeatingAdjustMode(mode)
+        except ValueError:
             return None
-        return SupplyHeatingAdjustMode(mode)
 
     @property
     def defrost_mode(self) -> Optional[DefrostMode]:
@@ -293,15 +298,16 @@ class MetricData:
             DefrostMode: 'Bypass'(0), 'Fanstop' (1)
         """
         mode = self.get("A_CYC_DEFROST_MODE")
-        if mode is None:
+        try:
+            return DefrostMode(mode)
+        except ValueError:
             return None
-        return DefrostMode(mode)
 
     def get_temperature_setting(self, profile: Profile) -> Optional[float]:
         """Get the temperature setting for the profile"""
         if profile not in PROFILE_TO_SET_TEMPERATURE_METRIC_MAP:
             raise ValloxInvalidInputException(
-                f"Temperature is not gettable for profile: {profile}"
+                f"Temperature is not gettable for profile: {str(profile)}"
             )
         return self.get(PROFILE_TO_SET_TEMPERATURE_METRIC_MAP[profile])
 
@@ -309,25 +315,28 @@ class MetricData:
         """Get the fan speed for the profile"""
         if profile not in PROFILE_TO_SET_FAN_SPEED_METRIC_MAP:
             raise ValloxInvalidInputException(
-                f"Fan speed is not gettable for profile: {profile}"
+                f"Fan speed is not gettable for profile: {str(profile)}"
             )
-        return self.get(PROFILE_TO_SET_FAN_SPEED_METRIC_MAP[profile])
+        value = self.get(PROFILE_TO_SET_FAN_SPEED_METRIC_MAP[profile])
+        return value if isinstance(value, int) else None
 
     def get_rh_sensor_control(self, profile: Profile) -> Optional[bool]:
         """Return true if the RH sensor control is enabled for the profile, false otherwise"""
         if profile not in PROFILE_TO_SET_RH_SENSOR_CONTROL_METRIC_MAP:
             raise ValloxInvalidInputException(
-                f"RH sensor control is not gettable for profile: {profile}"
+                f"RH sensor control is not gettable for profile: {str(profile)}"
             )
-        return self.get(PROFILE_TO_SET_RH_SENSOR_CONTROL_METRIC_MAP[profile])
+        value = self.get(PROFILE_TO_SET_RH_SENSOR_CONTROL_METRIC_MAP[profile])
+        return bool(value) if value is not None else None
 
     def get_co2_sensor_control(self, profile: Profile) -> Optional[bool]:
         """Return true if the CO2 sensor control is enabled for the profile, false otherwise"""
         if profile not in PROFILE_TO_SET_CO2_SENSOR_CONTROL_METRIC_MAP:
             raise ValloxInvalidInputException(
-                f"CO2 sensor control is not gettable for profile: {profile}"
+                f"CO2 sensor control is not gettable for profile: {str(profile)}"
             )
-        return self.get(PROFILE_TO_SET_CO2_SENSOR_CONTROL_METRIC_MAP[profile])
+        value = self.get(PROFILE_TO_SET_CO2_SENSOR_CONTROL_METRIC_MAP[profile])
+        return bool(value) if value is not None else None
 
     def get_remaining_profile_duration(self, profile: Profile) -> Optional[int]:
         """Get the remaining duration of the profile in minutes"""
@@ -521,7 +530,7 @@ class Vallox(Client):
         """Set the temperature for the profile"""
         if profile not in PROFILE_TO_SET_TEMPERATURE_METRIC_MAP:
             raise ValloxInvalidInputException(
-                f"Temperature is not settable for profile: {profile}"
+                f"Temperature is not settable for profile: {str(profile)}"
             )
         setting = PROFILE_TO_SET_TEMPERATURE_METRIC_MAP[profile]
 
@@ -563,22 +572,30 @@ class Vallox(Client):
     async def set_rh_sensor_control_mode(self, mode: int) -> None:
         """Set the RH sensor mode to manual (1) or automatic (0)"""
         if mode < 0 or mode > 1:
-            raise ValloxInvalidInputException("RH sensor control mode must be 0 (automatic) or 1 (manual)")
+            raise ValloxInvalidInputException(
+                "RH sensor control mode must be 0 (automatic) or 1 (manual)"
+            )
         await self.set_values({SET_RH_SENSOR_CONTROL_MODE: mode})
 
     async def set_rh_sensor_limit(self, percent: int) -> None:
         """Set the RH sensor limit (0-100). Only relevant if the RH sensor mode is set to 'manual'."""
         if percent < 0 or percent > 100:
-            raise ValloxInvalidInputException("RH sensor limit must be between 0 and 100")
+            raise ValloxInvalidInputException(
+                "RH sensor limit must be between 0 and 100"
+            )
         await self.set_values({SET_RH_SENSOR_CONTROL_LIMIT: percent})
 
     async def set_co2_sensor_limit(self, ppm: int) -> None:
         """Set the CO2 sensor ppm limit (500-2000)."""
         if ppm < 500 or ppm > 2000:
-            raise ValloxInvalidInputException("CO2 sensor limit must be between 500 and 2000")
+            raise ValloxInvalidInputException(
+                "CO2 sensor limit must be between 500 and 2000"
+            )
         await self.set_values({SET_CO2_SENSOR_CONTROL_LIMIT: ppm})
 
-    async def set_supply_heating_adjust_mode(self, mode: SupplyHeatingAdjustMode) -> None:
+    async def set_supply_heating_adjust_mode(
+        self, mode: SupplyHeatingAdjustMode
+    ) -> None:
         """Set the supply heating adjust mode.
         Args:
             mode: 0 (supply), 1 (extract), or 2 (cooling)
@@ -586,7 +603,9 @@ class Vallox(Client):
             ValloxInvalidInputException: If mode is not 0, 1, or 2
         """
         if not isinstance(mode, SupplyHeatingAdjustMode):
-            raise ValloxInvalidInputException("Mode must be a SupplyHeatingAdjustMode enum value (0, 1, or 2)")
+            raise ValloxInvalidInputException(
+                "Mode must be a SupplyHeatingAdjustMode enum value (0, 1, or 2)"
+            )
         await self.set_values({"A_CYC_SUPPLY_HEATING_ADJUST_MODE": mode.value})
 
     async def set_defrost_mode(self, mode: DefrostMode) -> None:
@@ -597,7 +616,9 @@ class Vallox(Client):
             ValloxInvalidInputException: If mode is not 0, 1, or 2
         """
         if not isinstance(mode, DefrostMode):
-            raise ValloxInvalidInputException("Mode must be a DefrostMode enum value (0 or 1)")
+            raise ValloxInvalidInputException(
+                "Mode must be a DefrostMode enum value (0 or 1)"
+            )
         await self.set_values({"A_CYC_DEFROST_MODE": mode.value})
 
     async def set_filter_change_date(self, _date: date) -> None:


### PR DESCRIPTION
Hi! First pull request for me, please help me get this right :).
Thank you for your work on the websocket API! It's really awesome to be able to hack on this myself instead of relying on proprietary stuff. I hope I can contribute back with this.

I tried to make this as clean as possible. Of course it makes much more sense with the Home Assistant side of things - I also have a commit for the HA Vallox component ready that will expose all these settables as switches/numbers/selects and also create more sensors for other data that is displayed in the Vallox web GUI. It only needs a bit of cleanup before it will go up for review, too. All settables have been tested in production to match what the web GUI does. There are a few more that I couldn't quite identify, e.g. some obscure defrost settings with offset/param pairs that I couldn't make sense of (value mismatches between Vallox GUI and API readouts).

- New settables:
  - A_CYC_<HOME|AWAY|BOOST>_RH_CTRL_ENABLED
  - A_CYC_<HOME|AWAY|BOOST>_CO2_CTRL_ENABLED
  - A_CYC_CO2_THRESHOLD
  - A_CYC_RH_LEVEL_MODE
  - A_CYC_RH_BASIC_LEVEL
  - A_CYC_PARTIAL_BYPASS
  - A_CYC_SUPPLY_HEATING_ADJUST_MODE
  - A_CYC_POST_HEATER_WINTER_SETPOINT
  - A_CYC_COOLRECOVERY_DISABLED
  - A_CYC_DEFROST_MODE
  - A_CYC_SUPPLY_AIR_DEFROST_TEMP
- These all correspond to options available in the Vallox web GUI.

- New enums:
  - CellState
  - SupplyHeatingAdjustMode
  - DefrostMode

- New helpers:
  - MetricData::supply_heating_adjust_mode()
  - MetricData::get_supply_heating_adjust_mode()
  - MetricData::get_supply_heating_adjust_mode_name()
  - MetricData::defrost_mode()
  - MetricData::get_defrost_mode()
  - MetricData::get_defrost_mode_name()
  - MetricData::get_rh_sensor_control()
  - MetricData::get_co2_sensor_control()
  - MetricData::get_rh_sensor_control_mode()
  - MetricData::get_rh_sensor_limit()
  - MetricData::get_co2_sensor_limit()
  - Vallox::set_rh_sensor_control()
  - Vallox::set_co2_sensor_control()
  - Vallox::set_rh_sensor_control_mode()
  - Vallox::set_rh_sensor_limit()
  - Vallox::set_co2_sensor_limit()
  - Vallox::set_supply_heating_adjust_mode()
  - Vallox::set_defrost_mode()